### PR TITLE
zendy-api to 2.0.0-rc.15

### DIFF
--- a/env/requirements.yaml
+++ b/env/requirements.yaml
@@ -9,4 +9,4 @@ dependencies:
   version: 2.3.58
 - name: zendy-api
   repository: http://jenkins-x-chartmuseum:8080
-  version: 2.0.0-rc.14
+  version: 2.0.0-rc.15


### PR DESCRIPTION
Promote zendy-api to version 2.0.0-rc.15