### PR TITLE
zendy-cockpit to 2.0.0-rc.2

### DIFF
--- a/env/requirements.yaml
+++ b/env/requirements.yaml
@@ -12,4 +12,4 @@ dependencies:
   version: 2.0.0-rc.17
 - name: zendy-cockpit
   repository: http://jenkins-x-chartmuseum:8080
-  version: 1.0.01
+  version: 2.0.0-rc.2


### PR DESCRIPTION
Promote zendy-cockpit to version 2.0.0-rc.2