### PR TITLE
zendy-cockpit to 2.0.0-rc.4

### DIFF
--- a/env/requirements.yaml
+++ b/env/requirements.yaml
@@ -12,4 +12,4 @@ dependencies:
   version: 2.0.0-rc.17
 - name: zendy-cockpit
   repository: http://jenkins-x-chartmuseum:8080
-  version: 2.0.0-rc.3
+  version: 2.0.0-rc.4


### PR DESCRIPTION
Promote zendy-cockpit to version 2.0.0-rc.4