### PR TITLE
zendy-api to 2.0.0-rc.20

### DIFF
--- a/env/requirements.yaml
+++ b/env/requirements.yaml
@@ -1,7 +1,7 @@
 dependencies:
 - name: zendy-api
   repository: http://jenkins-x-chartmuseum:8080
-  version: 2.0.0-rc.19
+  version: 2.0.0-rc.20
 - name: zendy-cockpit
   repository: http://jenkins-x-chartmuseum:8080
   version: 2.0.0-rc.11


### PR DESCRIPTION
Promote zendy-api to version 2.0.0-rc.20