### PR TITLE
zendy-ui to 2.0.0-rc.4

### DIFF
--- a/env/requirements.yaml
+++ b/env/requirements.yaml
@@ -7,4 +7,4 @@ dependencies:
   version: 2.0.0-rc.11
 - name: zendy-ui
   repository: http://jenkins-x-chartmuseum:8080
-  version: 0.1.02
+  version: 2.0.0-rc.4


### PR DESCRIPTION
Promote zendy-ui to version 2.0.0-rc.4