### PR TITLE
zendy-cockpit to 2.0.0-rc.12

### DIFF
--- a/env/requirements.yaml
+++ b/env/requirements.yaml
@@ -4,7 +4,7 @@ dependencies:
   version: 2.0.0-rc.20
 - name: zendy-cockpit
   repository: http://jenkins-x-chartmuseum:8080
-  version: 2.0.0-rc.11
+  version: 2.0.0-rc.12
 - name: zendy-ui
   repository: http://jenkins-x-chartmuseum:8080
   version: 0.1.06


### PR DESCRIPTION
Promote zendy-cockpit to version 2.0.0-rc.12